### PR TITLE
Null reference when timeout is set and no jobs are waiting in feed

### DIFF
--- a/job.js
+++ b/job.js
@@ -126,7 +126,7 @@ function jobPublish(item, callback, high_priority) {
 function jobGet(timeout, callback) {
     if(!timeout) timeout = 0;
     this.bredis.brpop("feed.ids:" + this.name, timeout, function(err, result) {
-        if(!err) {
+        if(!err && result) {
             var id = result[1];
             this.mredis.multi()
                 .zadd("feed.claimed:" + this.name, Date.now(), result[1])


### PR DESCRIPTION
It is late and I could be crazy, but I am getting a null ref when I do the following:

var someFeed = thoonk.job('my jobs');

var testJobGet = someFeed.get(5, function _get(item, id, timedout) {
    winston.info('[_get] should be called.');
  });

It seems that redis doesn't consider a missing key an to be an error on brpop's callback.
