### PR TITLE
add optional 4th param for Redis auth support

### DIFF
--- a/thoonk.js
+++ b/thoonk.js
@@ -21,7 +21,7 @@ var Feed = exports.Feed = require("./feed.js").Feed,
  * @param host
  * @param port
  */
-var Thoonk = exports.Thoonk = function Thoonk(host, port, db) {
+var Thoonk = exports.Thoonk = function Thoonk(host, port, db, password) {
     host || (host = "127.0.0.1");
     port || (port = 6379);
     db || (db = 0);
@@ -30,9 +30,15 @@ var Thoonk = exports.Thoonk = function Thoonk(host, port, db) {
     this.db = db;
     EventEmitter.call(this);
     this.lredis = redis.createClient(port, host);
+    if (typeof password != 'undefined') {
+        this.lredis.auth(password);
+    }
     this.lredis.select(db);
     this.lredis.subscribe("newfeed", "delfeed", "conffeed");
     this.mredis = redis.createClient(port, host);
+    if (typeof password != 'undefined') {
+        this.mredis.auth(password);
+    }
     this.mredis.select(db);
     this.lock = new padlock.Padlock();
 
@@ -416,10 +422,10 @@ Thoonk.prototype.getFeedNames = function(callback, error_callback) {
  * Shortcut function to make creating a Thoonk instance
  * easier, as so:
  *
- *     var pubsub = require("thoonk").createClient(host, port, db);
+ *     var pubsub = require("thoonk").createClient(host, port, db, password);
  */
-exports.createClient = function(host, port, db) {
-    return new Thoonk(host, port, db);
+exports.createClient = function(host, port, db, password) {
+    return new Thoonk(host, port, db, password);
 }
 
 exports.VERSION = '0.5.1';


### PR DESCRIPTION
```
$ grep ^requirepass /etc/redis/redis.conf 
requirepass booman
```

For this case, if I only provide Thoonk with hostname and port, then I get an error from RedisClient:

> Error Ready check failed: Error: ERR operation not permitted

I verified that existing tests all still pass as well as possible but I haven't committed the modifications of the tests supporting passwords because of a node_redis issue ( https://github.com/mranney/node_redis/issues/155 ): test_jobs uses 'ready' and current versions of node_redis fail due to an auth issue.

Thank you.
- jeremiah
