### PR TITLE
Follow error-first pattern for callbacks

### DIFF
--- a/feed.js
+++ b/feed.js
@@ -510,7 +510,7 @@ function feedDelete (callback) {
                     }.bind(this));
                 } else {
                     if(callback) {
-                        callback('Success', this.name);
+                        callback(null, this.name);
                     }
                 }
             }.bind(this));


### PR DESCRIPTION
I'd suggest following this pattern (of returning an error or falsy value in the first argument of callbacks). Many flowcontrol libraries expect this convention and is easier that string matching to know whether there's been an error or not. 
