### PR TITLE
Update hiredis dependency to 0.4.1 for happiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "async": "0.2.9",
         "node-uuid": "1.4.0",
-        "hiredis": "0.1.15",
+        "hiredis": "0.4.1",
         "redis": "0.8.4"
     },
     "devDependencies": {


### PR DESCRIPTION
thoonk does not install on node v0.12.x. If you update to the latest hiredis version, it works fine.
